### PR TITLE
Allow the log level to be configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ venv/
 
 # idea
 .idea/
+
+# Vim
+*.swp
+

--- a/rtmbot.conf.example
+++ b/rtmbot.conf.example
@@ -1,3 +1,11 @@
 DEBUG: False
 
 SLACK_TOKEN: "xoxb-123456789abcdefghijklmnopqrstuvwxyz"
+
+# Comment out to print to stdout instead
+LOGFILE: "/opt/SlackBot/log/log.log"
+
+# See https://docs.python.org/3/library/logging.html#logging-levels for table
+# of values you can use
+LOGLEVEL: 30
+

--- a/rtmbot.py
+++ b/rtmbot.py
@@ -156,7 +156,8 @@ class UnknownChannel(Exception):
 
 def main_loop():
     if "LOGFILE" in config:
-        logging.basicConfig(filename=config["LOGFILE"], level=logging.INFO, format='%(asctime)s %(message)s')
+        level = config["LOGLEVEL"] if "LOGLEVEL" in config else logging.INFO
+        logging.basicConfig(filename=config["LOGFILE"], level=level, format='%(asctime)s %(message)s')
     logging.info(directory)
     try:
         bot.start()


### PR DESCRIPTION
This makes it possible to log error messages, while avoiding filling the disk with lots of empty log entries (by only logging "warning" error messages, for instance).

I've tried this out in production, and it worked well.
