### PR TITLE
Reconnect when an occasional error occurs

### DIFF
--- a/plugins/fun_facts.py
+++ b/plugins/fun_facts.py
@@ -11,13 +11,13 @@ replace = {'\\"': '"'}
 remove = ["<strong>", "</strong>", "<em>", "</em>"]
 
 def process_message(data):
-	if data["text"] in [".fun", ".funfact", ".fact"]:
-		info = "[]"
-		while info == "[]":
-			info = urlopen(url + str(random.randint(bottom, top))).read().decode()
-		fact = info.split("</p>")[0][12:]
-		for a in replace:
-			fact = fact.replace(a, replace[a])
-		for a in remove:
-			fact = fact.replace(a, "")
-		outputs.append([data["channel"], fact])
+    if data["text"] in [".fun", ".funfact", ".fact"]:
+        info = "[]"
+        while info == "[]":
+            info = urlopen(url + str(random.randint(bottom, top))).read().decode()
+        fact = info.split("</p>")[0][12:]
+        for a in replace:
+            fact = fact.replace(a, replace[a])
+        for a in remove:
+            fact = fact.replace(a, "")
+        outputs.append([data["channel"], fact])


### PR DESCRIPTION
Prevously, the program would exit the moment an exception occurred. However, network errors are a fact of life, and so the SlackBot would appear rather instable, since it went down after a few days. With this PR, the SlackBot will just try to reconnect if an error occurs.

To prevent an endless loop when a consistent bug appears, the SlackBot will exit if exceptions occur less than 10 seconds apart. 
